### PR TITLE
Change raise statements to use parens around arguments.  Affects issue #62

### DIFF
--- a/src/spec2nexus/dev_spec.py
+++ b/src/spec2nexus/dev_spec.py
@@ -45,40 +45,40 @@ def developer_test(spec_file_name = None):
         #spec_file_name = os.path.join(spec_dir, '130123B_2.spc')
         spec_file_name = os.path.join(spec_dir, 'user6idd.dat')
         os.chdir(spec_dir)
-        print '-'*70
+        print ('-'*70)
     # now open the file and read it
     test = spec.SpecDataFile(spec_file_name)
     scan = test.getScan(1)
     scan.interpret()
-    #print scan.UXML_root
-    #print prettify(scan.UXML_root)
+    #print (scan.UXML_root)
+    #print (prettify(scan.UXML_root))
 
     if False:
         # tell us about the test file
-        print 'file', test.fileName
-        print 'headers', len(test.headers)
-        print 'scans', len(test.scans)
-        #print 'positioners in first scan:'; print test.scans[0].positioner
+        print ('file %s' % test.fileName)
+        print ('headers %d' % len(test.headers))
+        print ('scans %d' % len(test.scans))
+        #print ('positioners in first scan:'); print (test.scans[0].positioner)
         for scan in test.scans.values():
-            # print scan.scanNum, scan.date, scan.column_first, scan.positioner[scan.column_first], 'eV', 1e3*scan.metadata['DCM_energy']
-            print scan.scanNum, scan.scanCmd
-        print 'first scan: ', test.getMinScanNumber()
-        print 'last scan: ', test.getMaxScanNumber()
-        print 'positioners in last scan:'
+            # print (scan.scanNum, scan.date, scan.column_first, scan.positioner[scan.column_first], 'eV', 1e3*scan.metadata['DCM_energy'])
+            print (scan.scanNum, scan.scanCmd)
+        print ('first scan: %s' % test.getMinScanNumber())
+        print ('last scan: %s' % test.getMaxScanNumber())
+        print ('positioners in last scan:')
         last_scan = test.getScan(-1)
-        print last_scan.positioner
+        print (last_scan.positioner)
         pLabel = last_scan.column_first
         dLabel = last_scan.column_last
         if len(pLabel) > 0:
-            print last_scan.data[pLabel]
-            print len(last_scan.data[pLabel])
-            print pLabel, dLabel
+            print (last_scan.data[pLabel])
+            print (len(last_scan.data[pLabel]))
+            print (pLabel, dLabel)
             for i in range(len(last_scan.data[pLabel])):
-                print last_scan.data[pLabel][i], last_scan.data[dLabel][i]
-        print 'labels in scan 1:', test.getScan(1).L
+                print (last_scan.data[pLabel][i], last_scan.data[dLabel][i])
+        print ('labels in scan 1: %s' % test.getScan(1).L)
         if test.getScan(1) is not None:
-            print 'command line of scan 5:', test.getScan(5).scanCmd
-        print '\n'.join(test.getScanCommands([1, 2]))
+            print ('command line of scan 5: %s' % test.getScan(5).scanCmd)
+        print ('\n'.join(test.getScanCommands([1, 2])))
     pass
 
 

--- a/src/spec2nexus/eznx.py
+++ b/src/spec2nexus/eznx.py
@@ -241,7 +241,7 @@ def read_nexus_field(parent, dataset_name, astype=None):
     if astype is not None:
         dtype = astype
     if len(dataset.shape) > 1:
-        raise RuntimeError, "unexpected %d-D data" % len(dataset.shape)
+        raise RuntimeError( "unexpected %d-D data" % len(dataset.shape))
     if dataset.size > 1:
         return dataset[...].astype(dtype)   # as array
     else:

--- a/src/spec2nexus/h5toText.py
+++ b/src/spec2nexus/h5toText.py
@@ -470,7 +470,7 @@ def do_filelist(filelist, limit=5, show_attributes=True):
     for item in filelist:
         mc = H5toText(item)
         mc.array_items_shown = limit
-        print '\n'.join(mc.report(show_attributes) or '')
+        print ('\n'.join(mc.report(show_attributes) or ''))
 
 
 def main():

--- a/src/spec2nexus/h5toText.py
+++ b/src/spec2nexus/h5toText.py
@@ -114,7 +114,7 @@ class H5toText(object):
                         s += [ fmt % (indentation, '@path', linkref.path) ]
                 else:
                     msg = "unidentified %s: %s, %s", itemname, repr(classref), repr(linkref)
-                    raise Exception, msg
+                    raise Exception(msg)
 
         for value in groups:        # show things that look like groups
             itemname = value.name.split("/")[-1]

--- a/src/spec2nexus/nexus.py
+++ b/src/spec2nexus/nexus.py
@@ -168,17 +168,17 @@ def main():
     for spec_data_file_name in spec_data_file_name_list:
         if not os.path.exists(spec_data_file_name):
             msg = 'File not found: ' + spec_data_file_name
-            print msg
+            print (msg)
             continue
 
         if user_parms.reporting_level in (REPORTING_STANDARD, REPORTING_VERBOSE):
-            print 'reading SPEC data file: '+spec_data_file_name
+            print ('reading SPEC data file: '+spec_data_file_name)
         spec_data = spec.SpecDataFile(spec_data_file_name)
     
         scan_list = pick_scans(spec_data.getScanNumbers(), user_parms.scan_list)
         if user_parms.reporting_level in (REPORTING_VERBOSE):
-            print '  discovered', len(spec_data.scans.keys()), ' scans'
-            print '  converting scan number(s): '  +  ', '.join(map(str, scan_list))
+            print ('  discovered %d scans' % len(spec_data.scans.keys()))
+            print ('  converting scan number(s): '  +  ', '.join(map(str, scan_list)))
 
         basename = os.path.splitext(spec_data_file_name)[0]
         nexus_output_file_name = basename + user_parms.hdf5_extension
@@ -186,7 +186,7 @@ def main():
             out = writer.Writer(spec_data)
             out.save(nexus_output_file_name, scan_list)
             if user_parms.reporting_level in (REPORTING_STANDARD, REPORTING_VERBOSE):
-                print 'wrote NeXus HDF5 file: ' + nexus_output_file_name
+                print ('wrote NeXus HDF5 file: ' + nexus_output_file_name)
 
 
 if __name__ == "__main__":

--- a/src/spec2nexus/nexus.py
+++ b/src/spec2nexus/nexus.py
@@ -124,7 +124,7 @@ def parse_scan_list_spec(scan_list_spec):
         elif len(sublist) == 2:
             scan_list += range(int(sublist[0]), int(sublist[1])+1)
         else:
-            raise ValueError, 'improper scan list specifier: ' + sublist
+            raise ValueError('improper scan list specifier: ' + sublist)
 
     sl = []
     for item in sorted(scan_list):

--- a/src/spec2nexus/plugins/spec_common_spec2nexus.py
+++ b/src/spec2nexus/plugins/spec_common_spec2nexus.py
@@ -1060,7 +1060,7 @@ def data_lines_postprocessing(scan):
                     # only keep complete rows
                     for label, val in buf.items():
                         scan.data[label].append(val)
-            except ValueError, _exc:
+            except ValueError as _exc:
                 pass    # ignore bad data lines (could save it as such ...)
     scan.addH5writer('scan data', data_lines_writer)
 

--- a/src/spec2nexus/scanf.py
+++ b/src/spec2nexus/scanf.py
@@ -96,7 +96,7 @@ def _scanf_compile(fmt):
             format_pat += char
             i += 1
     if DEBUG:
-        print "DEBUG: %r -> %s" % (fmt, format_pat)
+        print ("DEBUG: %r -> %s" % (fmt, format_pat))
     format_re = re.compile(format_pat)
     if len(scanf_cache) > SCANF_CACHE_SIZE:
         scanf_cache.clear()

--- a/src/spec2nexus/spec.py
+++ b/src/spec2nexus/spec.py
@@ -296,15 +296,13 @@ class SpecDataFile(object):
     
     def getScanNumbers(self):
         '''return a list of all scan numbers sorted by scan number'''
-        def my_cmp(x, y):
-            return cmp(float(x), float(y))
-        return sorted(self.scans.keys(), my_cmp)
+        return sorted(self.scans.keys(), key=int)
     
     def getScanNumbersChronological(self):
         '''return a list of all scan numbers sorted by date'''
-        def my_cmp(x, y):
-            return cmp(time.strptime(x.date), time.strptime(y.date))
-        scans = sorted(self.scans.values(), my_cmp)
+        def byDate_key(scan):
+            return time.strptime(scan.date)
+        scans = sorted(self.scans.values(), key=byDate_key)
         return [_.scanNum for _ in scans]
     
     def getMinScanNumber(self):

--- a/src/spec2nexus/spec.py
+++ b/src/spec2nexus/spec.py
@@ -84,11 +84,11 @@ Get the first and last scan numbers from the file:
 
     >>> from spec2nexus import spec
     >>> spec_data = spec.SpecDataFile('path/to/my/spec_data.dat')
-    >>> print spec_data.fileName
+    >>> print (spec_data.fileName)
     path/to/my/spec_data.dat
-    >>> print 'first scan: ', spec_data.getFirstScanNumber()
+    >>> print ('first scan: ', spec_data.getFirstScanNumber())
     1
-    >>> print 'last scan: ', spec_data.getLastScanNumber()
+    >>> print ('last scan: ', spec_data.getLastScanNumber())
     22
 
 Get plottable data from scan number 10:

--- a/src/spec2nexus/spec.py
+++ b/src/spec2nexus/spec.py
@@ -205,9 +205,9 @@ class SpecDataFile(object):
         self.scans = {}
         self.readOK = -1
         if not os.path.exists(filename):
-            raise SpecDataFileNotFound, 'file does not exist: ' + str(filename)
+            raise SpecDataFileNotFound('file does not exist: ' + str(filename))
         if not is_spec_file(filename):
-            raise NotASpecDataFile, 'not a SPEC data file: ' + str(filename)
+            raise NotASpecDataFile('not a SPEC data file: ' + str(filename))
         self.fileName = filename
 
         if plugin_manager is None:
@@ -269,7 +269,7 @@ class SpecDataFile(object):
             buf = open(spec_file_name, 'r').read()
         except IOError:
             msg = 'Could not open spec file: ' + str(spec_file_name)
-            raise SpecDataFileCouldNotOpen, msg
+            raise SpecDataFileCouldNotOpen(msg)
         if not is_spec_file(spec_file_name):
             msg = 'Not a spec data file: ' + str(spec_file_name)
             raise NotASpecDataFile(msg)
@@ -554,5 +554,5 @@ class SpecDataFileScan(object):
             i += 1
             key = label + '_' + str(i)
             if i == 1000:
-                raise RuntimeError, "cannot make unique key for duplicated column label!"
+                raise RuntimeError("cannot make unique key for duplicated column label!")
         return key

--- a/src/spec2nexus/specplot_gallery.py
+++ b/src/spec2nexus/specplot_gallery.py
@@ -166,7 +166,7 @@ class PlotSpecFileScans(object):
             altText = '#' + str(scan.scanNum) + ': ' + scan.scanCmd
             href = self.href_format(basePlotFile, altText)
             
-            #print "specplot.py %s %s %s" % (specFile, scan.scanNum, fullPlotFile)
+            #print ("specplot.py %s %s %s" % (specFile, scan.scanNum, fullPlotFile))
             if needToMakePlot(fullPlotFile, mtime_specFile):
                 try:
                     logger('  creating SPEC data scan image: ' + basePlotFile)

--- a/src/spec2nexus/utils.py
+++ b/src/spec2nexus/utils.py
@@ -54,7 +54,7 @@ def clean_name(key):
 
 def get_all_plugins():
     '''load all spec2nexus plugin modules'''
-    import plugin
+    import spec2nexus.plugin as plugin
     manager = plugin.PluginManager()
     manager.load_plugins()
     return manager

--- a/src/spec2nexus/uxml/test_uxml.py
+++ b/src/spec2nexus/uxml/test_uxml.py
@@ -82,7 +82,7 @@ class TestPlugin(unittest.TestCase):
 			if len(txt) > 0:
 				uxml.process(txt, self.scan)
 		self.assertTrue(hasattr(self.scan, 'UXML'))
-		#print '\n'.join([ '%3d: %s' % (i,j) for i,j in enumerate(self.scan.UXML) ])
+		#print ('\n'.join([ '%3d: %s' % (i,j) for i,j in enumerate(self.scan.UXML) ]))
 		self.assertEquals(9, len(self.scan.UXML))
 		self.assertTrue(hasattr(self.scan, 'h5writers'))
 		self.assertFalse('UXML_metadata' in self.scan.h5writers)
@@ -145,7 +145,7 @@ class TestData(unittest.TestCase):
 		for tname in (self.hname,):
 			if os.path.exists(tname):
 				os.remove(tname)
-				#print "removed test file:", tname
+				#print ("removed test file: %s" % tname)
 				pass
 
 	def testName(self):
@@ -159,7 +159,7 @@ class TestData(unittest.TestCase):
 		self.assertTrue(isinstance(dd, dict))
 		
 		#scan = spec_data.scans[1]
-		#print etree.tostring(scan.UXML_root)
+		#print (etree.tostring(scan.UXML_root))
 
 
 if __name__ == "__main__":

--- a/src/spec2nexus/writer.py
+++ b/src/spec2nexus/writer.py
@@ -18,11 +18,11 @@
 import h5py
 import numpy as np
 
-import eznx
+import spec2nexus.eznx as eznx
 import spec2nexus
-import spec
-import utils
-
+import spec2nexus.spec as spec
+import spec2nexus.utils as spec
+ 
 
 # see: http://download.nexusformat.org/doc/html/classes/base_classes/index.html
 #CONTAINER_CLASS = 'NXlog'          # information that is recorded against time

--- a/src/spec2nexus/writer.py
+++ b/src/spec2nexus/writer.py
@@ -21,7 +21,7 @@ import numpy as np
 import spec2nexus.eznx as eznx
 import spec2nexus
 import spec2nexus.spec as spec
-import spec2nexus.utils as spec
+import spec2nexus.utils as utils
  
 
 # see: http://download.nexusformat.org/doc/html/classes/base_classes/index.html


### PR DESCRIPTION
I was working on trying to get my application working with Python 3 and stumbled on this low hanging fruit in spec2nexus.  Just like it says, I found that arguments to raise must be enclosed in parentheses per https://docs.python.org/3.0/whatsnew/3.0.html#changes-to-exceptions.  Minor changes here.  This should be a step toward Issue #62 